### PR TITLE
🐞 [WIP] Fix token ID increments

### DIFF
--- a/src/DN404.sol
+++ b/src/DN404.sol
@@ -438,7 +438,7 @@ abstract contract DN404 {
             $.totalSupply = uint96(totalSupply_);
             uint256 overflows = _toUint(_totalSupplyOverflows(totalSupply_));
             if (overflows | _toUint(totalSupply_ < amount) != 0) revert TotalSupplyOverflow();
-            maxId = totalSupply_ / _unit();
+            maxId = totalSupply_ + amount / _unit();
         }
         unchecked {
             if (_isZero(toAddressData.flags & _ADDRESS_DATA_SKIP_NFT_FLAG)) {
@@ -520,7 +520,7 @@ abstract contract DN404 {
             $.totalSupply = uint96(totalSupply_);
             uint256 overflows = _toUint(_totalSupplyOverflows(totalSupply_));
             if (overflows | _toUint(totalSupply_ < amount) != 0) revert TotalSupplyOverflow();
-            maxId = totalSupply_ / _unit();
+            maxId = totalSupply_ + amount / _unit();
         }
         unchecked {
             if (_isZero(toAddressData.flags & _ADDRESS_DATA_SKIP_NFT_FLAG)) {

--- a/test/DN404.t.sol
+++ b/test/DN404.t.sol
@@ -156,7 +156,12 @@ contract DN404Test is SoladyTest {
         dn.mint(initialSupplyOwner, 3 * _WAD);
         assertEq(mirror.balanceOf(initialSupplyOwner), 5);
 
-        for (uint256 i = 1; i <= 5; ++i) {
+        for (uint256 i = 1; i <= 2; ++i) {
+            assertEq(mirror.ownerOf(i), initialSupplyOwner);
+        }
+
+        // leave out the burned range
+        for (uint256 i = 5; i <= 7; ++i) {
             assertEq(mirror.ownerOf(i), initialSupplyOwner);
         }
 
@@ -195,7 +200,38 @@ contract DN404Test is SoladyTest {
         dn.mint(initialSupplyOwner, 1);
         assertEq(mirror.balanceOf(initialSupplyOwner), 2);
 
-        for (uint256 i = 1; i <= 2; ++i) {
+        assertEq(mirror.ownerOf(1), initialSupplyOwner);
+        assertEq(mirror.ownerOf(3), initialSupplyOwner);
+
+        uint256 count;
+        for (uint256 i = 0; i < 10; ++i) {
+            if (mirror.ownerAt(i) == initialSupplyOwner) ++count;
+        }
+        assertEq(count, 2);
+    }
+
+    function testMintAndBurn3() public {
+        address initialSupplyOwner = address(1111);
+
+        dn.initializeDN404(0, initialSupplyOwner, address(mirror));
+
+        assertEq(dn.getSkipNFT(initialSupplyOwner), false);
+        assertEq(dn.getSkipNFT(address(this)), true);
+
+        vm.prank(initialSupplyOwner);
+        dn.setSkipNFT(false);
+        dn.setAddToBurnedPool(true);
+
+        dn.mint(initialSupplyOwner, 4 * _WAD);
+        assertEq(mirror.balanceOf(initialSupplyOwner), 4);
+
+        dn.burn(initialSupplyOwner, 2 * _WAD);
+        assertEq(mirror.balanceOf(initialSupplyOwner), 2);
+
+        dn.mint(initialSupplyOwner, 3 * _WAD);
+        assertEq(mirror.balanceOf(initialSupplyOwner), 5);
+
+        for (uint256 i = 1; i <= 5; ++i) {
             assertEq(mirror.ownerOf(i), initialSupplyOwner);
         }
 
@@ -203,7 +239,10 @@ contract DN404Test is SoladyTest {
         for (uint256 i = 0; i < 10; ++i) {
             if (mirror.ownerAt(i) == initialSupplyOwner) ++count;
         }
-        assertEq(count, 2);
+        assertEq(count, 5);
+
+        dn.mint(initialSupplyOwner, 3 * _WAD);
+        assertEq(mirror.balanceOf(initialSupplyOwner), 8);
     }
 
     function testSetAndGetSkipNFT() public {


### PR DESCRIPTION
## Description

I assumed NFT IDs would increment as described in #51. Meaning: 

```
User A mints 3 NFTs = Token IDs 1,2,3 are minted
User A burns 1 NFT = Token ID 1 is burned
User A mints 1 NFT = Token ID 4 is minted
```

This behaviour unless `addToBurnedPool` is returning true. My change makes the token IDs increment like that. 

I'm not 100% sure what the desired way to increment token IDs is but I think not automatically recycling helps for different use cases.

## Notes

The `testMixed` is currently failing. Will fix that if my assumption is right. 


